### PR TITLE
Raise kibana resource requests to meet minimums

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -108,8 +108,8 @@ objects:
               cpu: 50m
               memory: 100Mi
             requests:
-              cpu: 20m
-              memory: 50Mi
+              cpu: 50m
+              memory: 100Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -145,8 +145,8 @@ objects:
               cpu: 50m
               memory: 100Mi
             requests:
-              cpu: 20m
-              memory: 50Mi
+              cpu: 50m
+              memory: 100Mi
           image: quay.io/app-sre/nginx:alpine
           name: es-init-template
         restartPolicy: Always


### PR DESCRIPTION
Based on a kibana error: 
`pods "kibana-78d8bc656f-zqzp9" is forbidden: [memory max limit to request ratio per Container is 2, but provided ratio is 19.000000, minimum cpu usage per Container is 50m, but request is 20m, minimum memory usage per Container is 100Mi, but request is 50Mi]`
