### PR TITLE
Fix incorrect memory limit ratio

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -75,7 +75,7 @@ objects:
               memory: 1900Mi
             requests:
               cpu: 200m
-              memory: 100Mi
+              memory: 800Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - args:


### PR DESCRIPTION
Based on: 
`Error creating: pods "kibana-69cc9549-sq259" is forbidden: memory max limit to request ratio per Container is 2, but provided ratio is 19.000000`