### PR TITLE
Changes number_of_shards per index from 5 to 3

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -127,7 +127,7 @@ objects:
           - 'set -ex
 
             curl -XPUT "$ELASTICSEARCH_HOSTS/_template/template_1" -H ''Content-Type:
-            application/json'' -d''{"template": "cwl-*","settings": {"index.mapping.total_fields.limit":
+            application/json'' -d''{"template": "cwl-*","settings": {"number_of_shards": 3, "index.mapping.total_fields.limit":
             4000},"mappings": {"dynamic_templates": [{"host_tags": {"match_mapping_type":
             "string","path_match": "*host.tags.*","mapping": {"index": false}}}]}}''
 


### PR DESCRIPTION
**Proposal:** The default number of shards for each index is 5. Each shard has a replica, so there are 10 total shards per log group. As our indexes are mostly tiny, 3 shards should be sufficient for our space requirements. With 1 replica per index, the total will be 6; bringing us to a 40% reduction in shard count.

If we want to start with 4 and work back down, that's fine too. Or we can turn off replicas entirely and keep 5. 