### PR TITLE
remove admin_user_credentials

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -69,18 +69,6 @@ objects:
               secretKeyRef:
                 key: endpoint
                 name: kibana-elasticsearch
-          - name: USER
-            valueFrom:
-              secretKeyRef:
-                key: username
-                name: admin_user_credentials
-                optional: true
-          - name: PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: password
-                name: admin_user_credentials
-                optional: true
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: kibana


### PR DESCRIPTION
`Invalid value: "admin_user_credentials": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`