### PR TITLE
Migrate from kibana-oss to kibana image (7.10.2)

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -201,11 +201,11 @@ objects:
 parameters:
 - description: Image namespace
   name: IMAGE
-  value: quay.io/cloudservices/kibana-oss
+  value: docker.elastic.co/kibana/kibana
 - description: Image tag
   name: IMAGE_TAG
   required: true
-  value: 7.9.3
+  value: 7.10.2
 - name: OAUTH_IMAGE
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_IMAGE_TAG


### PR DESCRIPTION
Switch from abandoned kibana-oss distribution to official kibana image. Staying on version 7.10.2 to maintain compatibility with AWS Elasticsearch 7.10.

Changes:
- Update default IMAGE parameter: quay.io/cloudservices/kibana-oss → docker.elastic.co/kibana/kibana
- Update default IMAGE_TAG: 7.9.3 → 7.10.2

Background: The kibana-oss (Open Source Software) distribution was discontinued after version 7.10.2 and no longer receives security patches. The standard kibana:7.10.2 image is still Apache 2.0 licensed and addresses CVE notifications while maintaining ES 7.10 compatibility.

Note: These template defaults are overridden by app-interface deployment config, but keeping them in sync with deployed versions.